### PR TITLE
BUG FIX: Conversion functions correctly applied to foreign reference …

### DIFF
--- a/src/mongrel_transferrer/mongrel/objects/table.py
+++ b/src/mongrel_transferrer/mongrel/objects/table.py
@@ -256,7 +256,9 @@ class Table:
                         self.columns.append(
                             Column(f'{rel_info.table}_{other_col.target_name}', other_col.path,
                                    other_col.sql_definition,
-                                   Field.PRIMARY_KEY if fk_are_pk else Field.FOREIGN_KEY, rel_info))
+                                   Field.PRIMARY_KEY if fk_are_pk else Field.FOREIGN_KEY, rel_info,
+                                   conversion_function=other_col.conversion_function,
+                                   conversion_args=other_col.conversion_args))
         for column in self.columns:
             if column.field_type == Field.PRIMARY_KEY and column.target_name not in self.pks:
                 self.pks.append(column.target_name)

--- a/src/mongrel_transferrer/mongrel/objects/transferrer.py
+++ b/src/mongrel_transferrer/mongrel/objects/transferrer.py
@@ -192,6 +192,7 @@ class Transferrer:
                     if vals:
                         df = pd.DataFrame.from_dict(vals, orient='index').transpose()
                         relation_info = relation.info if not relation.alias else relation.alias
+                        df = df.dropna(axis=0, how='all')
                         data[relation_info] = pd.concat([data[relation_info], df], ignore_index=True)
                         data[relation_info].drop_duplicates(relation.pks)
                 for relation in self.relations:


### PR DESCRIPTION
…columns

table.py
Adding the conversion function to the newly created columns

transferrer.py
Adding na check due to deprecation of empty concat